### PR TITLE
And-29 добавить неактивное состояние для кнопки передать показания

### DIFF
--- a/f-metrics/src/main/java/ru/surfstudio/standard/f_metrics/MetricsFragmentView.kt
+++ b/f-metrics/src/main/java/ru/surfstudio/standard/f_metrics/MetricsFragmentView.kt
@@ -14,6 +14,7 @@ import ru.surfstudio.standard.f_metrics.controller.IpuController
 import ru.surfstudio.standard.f_metrics.databinding.FragmentMetricsBinding
 import ru.surfstudio.standard.f_metrics.di.MetricsScreenConfigurator
 import ru.surfstudio.standard.ui.mvi.view.BaseMviFragmentView
+import ru.surfstudio.standard.ui.util.performIfChanged
 import ru.surfstudio.standard.v_message_controller_top.IconMessageController
 import javax.inject.Inject
 
@@ -62,6 +63,14 @@ internal class MetricsFragmentView : BaseMviFragmentView<MetricsState, MetricsEv
 
     override fun render(state: MetricsState) {
         easyAdapter.setData(state.metricsUiItems, ipuController)
+        with(binding) {
+            metricsSendBtn.performIfChanged(state.canSendIpu) { canSendIpu ->
+                visibility = if (!canSendIpu) View.INVISIBLE else View.VISIBLE
+            }
+            metricsSendDisabledBtn.performIfChanged(state.canSendIpu) { canSendIpu ->
+                visibility = if (canSendIpu) View.INVISIBLE else View.VISIBLE
+            }
+        }
     }
 
     private fun initCommands() {

--- a/f-metrics/src/main/java/ru/surfstudio/standard/f_metrics/MetricsReducer.kt
+++ b/f-metrics/src/main/java/ru/surfstudio/standard/f_metrics/MetricsReducer.kt
@@ -22,7 +22,7 @@ internal data class MetricsState(
         get() = metricsUiItems.isEmpty() && ipuRequest.isLoading
 
     val showError: Boolean
-        get() = metricsUiItems.isEmpty() && ipuRequest.hasError
+        get() = !showLoading && ipuRequest.hasError
 
     val canSendIpu: Boolean
         get() = metricsUiItems.isNotEmpty()

--- a/f-metrics/src/main/java/ru/surfstudio/standard/f_metrics/MetricsReducer.kt
+++ b/f-metrics/src/main/java/ru/surfstudio/standard/f_metrics/MetricsReducer.kt
@@ -13,7 +13,11 @@ import javax.inject.Inject
 
 internal data class MetricsState(
     val metricsUiItems: List<MetricsUi> = emptyList()
-)
+) {
+
+    val canSendIpu: Boolean
+        get() = metricsUiItems.isNotEmpty()
+}
 
 /**
  * State Holder [MetricsFragmentView]

--- a/f-metrics/src/main/res/layout/fragment_metrics.xml
+++ b/f-metrics/src/main/res/layout/fragment_metrics.xml
@@ -26,6 +26,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginTop="48dp"
+            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/metrics_send_btn"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -63,11 +64,11 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/metrics_send_disabled_btn"
             style="@style/Button.Gray"
-            android:enabled="false"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
             android:layout_marginBottom="16dp"
+            android:enabled="false"
             android:paddingVertical="8dp"
             android:text="@string/metrics_send_btn"
             app:layout_constraintBottom_toBottomOf="parent" />

--- a/f-metrics/src/main/res/layout/fragment_metrics.xml
+++ b/f-metrics/src/main/res/layout/fragment_metrics.xml
@@ -40,5 +40,17 @@
             android:text="@string/metrics_send_btn"
             app:layout_constraintBottom_toBottomOf="parent" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/metrics_send_disabled_btn"
+            style="@style/Button.Gray"
+            android:enabled="false"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginBottom="16dp"
+            android:paddingVertical="8dp"
+            android:text="@string/metrics_send_btn"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/f-pay/src/main/java/ru/surfstudio/standard/f_pay/PayReducer.kt
+++ b/f-pay/src/main/java/ru/surfstudio/standard/f_pay/PayReducer.kt
@@ -29,7 +29,7 @@ internal data class PayState(
         get() = payUiItems.isEmpty() && ipuRequest.isLoading
 
     val showError: Boolean
-        get() = payUiItems.isEmpty() && ipuRequest.hasError
+        get() = !showLoading && ipuRequest.hasError
 }
 
 /**

--- a/f-pay/src/main/res/layout/fragment_pay.xml
+++ b/f-pay/src/main/res/layout/fragment_pay.xml
@@ -21,6 +21,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="48dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/pay_send_btn"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -70,11 +71,11 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/pay_send_disabled_btn"
         style="@style/Button.Gray"
-        android:enabled="false"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
         android:layout_marginBottom="16dp"
+        android:enabled="false"
         android:paddingVertical="8dp"
         android:text="@string/pay_btn"
         app:layout_constraintBottom_toBottomOf="parent" />


### PR DESCRIPTION
## Добавить неактивное состояние для кнопки передать показания

#### Ссылка на задачу: https://trello.com/c/d8VHgBPQ/55-and-29-добавить-неактивное-состояние-для-кнопки-передать-показания

Добавлено неактивное состояние для кнопки "Передать показания".
Исправлено появление экрана с ошибкой.

### Скриншоты/видео

<details>
<summary>Неактивное состояние</summary>

![image](https://github.com/SaVyrin/TP-4.2-2_Project/assets/83529931/ea8e36ac-d8c8-4ec5-a3bb-06de05a433a5)
</details>